### PR TITLE
Explicitly remove all importSpecifiers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,9 @@ export class ImportUtil {
         .get('specifiers')
         .find((specifierPath) => matchSpecifier(specifierPath, exportedName));
       if (importSpecifierPath) {
-        if (topLevelPath.node.specifiers.length === 1) {
+        importSpecifierPath.remove();
+        if (topLevelPath.node.specifiers.length === 0) {
           topLevelPath.remove();
-        } else {
-          importSpecifierPath.remove();
         }
       }
     }
@@ -31,6 +30,9 @@ export class ImportUtil {
   removeAllImports(moduleSpecifier: string): void {
     for (let topLevelPath of this.program.get('body')) {
       if (matchModule(topLevelPath, moduleSpecifier)) {
+        for (let specifier of topLevelPath.get('specifiers')) {
+          specifier.remove();
+        }
         topLevelPath.remove();
       }
     }


### PR DESCRIPTION
The changes in https://github.com/ef4/babel-import-util/pull/3 made babel aware of our newly-inserted import specifiers, which causes it to schedule visits on them. If subsequent code removes them again before they've been visited, babel still visits them but passes paths with a broken parent.

Explicitly removing all specifiers seems to convince babel to remove them from its scheduled visit queue.

Fixes https://github.com/ef4/babel-import-util/issues/5