### PR TITLE
Sanitize name hints

### DIFF
--- a/__tests__/import-util.test.ts
+++ b/__tests__/import-util.test.ts
@@ -62,6 +62,16 @@ function importUtilTests(transform: (code: string) => string) {
     expect(code).toMatch(/import HINT from ['"]m['"]/);
   });
 
+  test('sanitizes name hint to make it a valid javascript identifier', () => {
+    let code = transform(`
+      export default function() {
+        return myMessyHintTarget('foo');
+      }
+      `);
+    expect(runDefault(code, { dependencies })).toEqual('default said: foo.');
+    expect(code).toMatch(/import thisIsTheHint from ['"]m['"]/);
+  });
+
   test('avoids an existing local binding', () => {
     let code = transform(`
       export default function() {
@@ -231,6 +241,8 @@ function testTransform(babel: { types: typeof t }): unknown {
           callee.replaceWith(state.adder.import(callee, 'm', 'default'));
         } else if (callee.node.name === 'myHintTarget') {
           callee.replaceWith(state.adder.import(callee, 'm', 'default', 'HINT'));
+        } else if (callee.node.name === 'myMessyHintTarget') {
+          callee.replaceWith(state.adder.import(callee, 'm', 'default', 'this-is: the hint!'));
         } else if (callee.node.name === 'needsSideEffectThing') {
           state.adder.importForSideEffect('side-effect-thing');
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,13 @@ function name(node: t.StringLiteral | t.Identifier): string {
 
 function desiredName(nameHint: string | undefined, exportedName: string, target: NodePath<t.Node>) {
   if (nameHint) {
-    return nameHint;
+    // first we opportunistically do camelization when an illegal character is
+    // followed by a lowercase letter, in an effort to aid readability of the
+    // output.
+    let cleaned = nameHint.replace(/[^a-zA-Z_]([a-z])/g, (_m, letter) => letter.toUpperCase());
+    // then we unliterally strip all remaining illegal characters.
+    cleaned = cleaned.replace(/[^a-zA-Z_]/g, '');
+    return cleaned;
   }
   if (exportedName === 'default' || exportedName === '*') {
     if (target.isIdentifier()) {


### PR DESCRIPTION
Rather than make users always ensure their nameHints are valid javascript identifiers, we can just do that automatically for them here.