### PR TITLE
Bug in default import insertion order

### DIFF
--- a/__tests__/import-util.test.ts
+++ b/__tests__/import-util.test.ts
@@ -155,11 +155,13 @@ function importUtilTests(transform: (code: string) => string) {
   test('multiple uses share an import', () => {
     let code = transform(`
       export default function() {
-        return myTarget("a") + " | " + myTarget("b");
+        return myTarget("a") + " | " + myTarget("b") + " | " + myDefaultTarget("c");
       }
       `);
-    expect(runDefault(code, { dependencies })).toEqual('you said: a. | you said: b.');
-    expect(code).toMatch(/import \{ thing \} from ['"]m['"]/);
+    expect(code).toMatch(/import myDefaultTarget, \{ thing \} from ['"]m['"]/);
+    expect(runDefault(code, { dependencies })).toEqual(
+      'you said: a. | you said: b. | default said: c.'
+    );
     expect(code.match(/import/g)?.length).toEqual(1);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,11 @@ export class ImportUtil {
       unusedNameLike(target, desiredName(nameHint, exportedName, target))
     );
     let specifier = this.buildSpecifier(exportedName, local);
-    declaration.node.specifiers.push(specifier);
+    if (specifier.type === 'ImportDefaultSpecifier') {
+      declaration.node.specifiers.unshift(specifier);
+    } else {
+      declaration.node.specifiers.push(specifier);
+    }
     declaration.scope.registerBinding(
       'module',
       declaration.get(`specifiers.${declaration.node.specifiers.length - 1}`) as NodePath


### PR DESCRIPTION
When inserting a default import on an existing statement that has named imports, it's important the ImportDefaultSpecifier goes first. Otherwise babel treats it as named.

Found and fixed with @lukemelia.
