### PR TITLE
do not merge with existing declaration when exportedName is *

### DIFF
--- a/__tests__/import-util.test.ts
+++ b/__tests__/import-util.test.ts
@@ -87,6 +87,17 @@ function importUtilTests(transform: (code: string) => string) {
     expect(code).toMatch(/import \* as myNamespaceTarget from ['"]m['"]/);
   });
 
+  test('namespace binding avoids namespace imports', () => {
+    let code = transform(`
+      import * as foo from 'm';
+      export default function(foo) {
+        return myNamespaceTarget.thing('a') + " " + myNamespaceTarget.default('b');
+      }
+      `);
+    expect(runDefault(code, { dependencies })).toEqual('you said: a. default said: b.');
+    expect(code).toMatch(/import \* as myNamespaceTarget from ['"]m['"]/);
+  });
+
   test('namespace binding avoids named imports', () => {
     let code = transform(`
       import { x } from 'm';

--- a/__tests__/import-util.test.ts
+++ b/__tests__/import-util.test.ts
@@ -87,6 +87,58 @@ function importUtilTests(transform: (code: string) => string) {
     expect(code).toMatch(/import \* as myNamespaceTarget from ['"]m['"]/);
   });
 
+  test('namespace binding avoids named imports', () => {
+    let code = transform(`
+      import { x } from 'm';
+      export default function() {
+        return myNamespaceTarget.thing('a') + " " + myNamespaceTarget.default('b');
+      }
+      `);
+    expect(runDefault(code, { dependencies })).toEqual('you said: a. default said: b.');
+    expect(code).toMatch(/import \* as myNamespaceTarget from ['"]m['"]/);
+  });
+
+  test('namespace binding uses namespaced imports', () => {
+    let code = transform(`
+      import * as b from 'm';
+      export default function() {
+        return myNamespaceTarget.thing('a') + " " + myNamespaceTarget.default('b');
+      }
+      `);
+    expect(runDefault(code, { dependencies })).toEqual('you said: a. default said: b.');
+    expect(code).toMatch(/import \* as b from ['"]m['"]/);
+  });
+
+  test('namespace binding uses default imports', () => {
+    let code = transform(`
+      import b from 'm';
+      export default function() {
+        return myNamespaceTarget.thing('a') + " " + myNamespaceTarget.default('b');
+      }
+      `);
+    expect(runDefault(code, { dependencies })).toEqual('you said: a. default said: b.');
+    expect(code).toMatch(/import b, \* as myNamespaceTarget from ['"]m['"]/);
+  });
+
+  test('named binding avoids namespace import', () => {
+    let code = transform(`
+      import * as x from 'm';
+      export default function () {
+        myTarget();
+        second();
+      }
+    `);
+    expect(code).toEqualCode(`
+      import * as x from 'm';
+      import { thing } from "m";
+      import { thing as thing0 } from "n";
+      export default function () {
+        thing();
+        thing0();
+      }
+    `);
+  });
+
   test('can use an optional name hint', () => {
     let code = transform(`
       export default function() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,13 +60,17 @@ export class ImportUtil {
       (s) => s.type === 'ImportNamespaceSpecifier'
     );
     let hasNamedSpecifiers = declaration?.node.specifiers.find((s) => s.type === 'ImportSpecifier');
+
     /**
      * the file has a preexisting non-namespace import and a transform tries to add a namespace import, so they don't get combined
      * the file has a preexisting namespace import and a transform tries to add a non-namespace import, so they don't get combined
-     * the file has a preexisting namespace import and a transform tries to add a namespace import, so they get combined
+     * the file has a preexisting namespace import and a transform tries to add a namespace import, so they don't get combined
      */
     let cannotUseExistingDeclaration =
-      (hasNamedSpecifiers && isNamespaceImport) || (hasNamespaceSpecifier && isNamedImport);
+      (hasNamedSpecifiers && isNamespaceImport) ||
+      (hasNamespaceSpecifier && isNamedImport) ||
+      (hasNamespaceSpecifier && isNamespaceImport);
+
     if (!cannotUseExistingDeclaration && declaration) {
       let specifier = declaration
         .get('specifiers')


### PR DESCRIPTION
e.g. this is not supported, not in js nor ts: 
`import { a as b }, * as runner from "<module-name>"`
`import { a as b , * as runner } from "<module-name>"`