### PR TITLE
Reference-aware API

### DIFF
--- a/__tests__/import-util.test.ts
+++ b/__tests__/import-util.test.ts
@@ -1,12 +1,46 @@
-import { allBabelVersions, runDefault } from './test-support';
+import { runDefault } from './test-support';
 import { ImportUtil } from '../src/index';
-import type { NodePath } from '@babel/traverse';
+import type * as Babel from '@babel/core';
+import type { PluginObj, TransformOptions, PluginItem, Visitor } from '@babel/core';
+import { transform as transform7 } from '@babel/core';
 // @ts-ignore no upstream types
 import TSSyntax from '@babel/plugin-syntax-typescript';
-import type * as t from '@babel/types';
 import 'code-equality-assertions/jest';
 
-function importUtilTests(transform: (code: string) => string) {
+describe('ImportUtil', () => {
+  let testTransform: PluginItem | undefined;
+  let t: typeof Babel.types;
+
+  function makePlugin(visitor: Visitor<State>) {
+    testTransform = function testTransform(babel: typeof Babel): PluginObj<State> {
+      t = babel.types;
+      return {
+        visitor: {
+          ...visitor,
+          Program: {
+            enter(path, state) {
+              state.util = new ImportUtil(babel, path);
+            },
+            ...(visitor.Program ?? {}),
+          },
+        },
+      };
+    };
+  }
+
+  function transform(code: string) {
+    if (!testTransform) {
+      throw new Error(`each test must call makePlugin`);
+    }
+    let options7: TransformOptions = {
+      plugins: [testTransform, TSSyntax],
+    };
+    if (!options7.filename) {
+      options7.filename = 'sample.js';
+    }
+    return transform7(code, options7)!.code!;
+  }
+
   const dependencies = {
     m: {
       thing(arg: string) {
@@ -25,7 +59,22 @@ function importUtilTests(transform: (code: string) => string) {
     },
   };
 
+  afterEach(() => {
+    testTransform = undefined;
+  });
+
   test('can generate an import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       export default function() {
         return myTarget('foo');
@@ -36,6 +85,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('can generate a default import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myDefaultTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'default'));
+        }
+      },
+    });
     let code = transform(`
       export default function() {
         return myDefaultTarget('foo');
@@ -46,6 +106,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('emits new imports after preexisting other imports', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myDefaultTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'default'));
+        }
+      },
+    });
     let code = transform(`
       import "whatever";
 
@@ -63,6 +134,19 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('emits added imports in the order they were added', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        } else if (callee.node.name === 'second') {
+          state.util.replaceWith(callee, (i) => i.import('n', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       export default function () {
         myTarget();
@@ -80,6 +164,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('can generate a namespace import', () => {
+    makePlugin({
+      MemberExpression(path, state) {
+        let obj = path.get('object');
+        if (!obj.isIdentifier()) {
+          return;
+        }
+        if (obj.node.name === 'myNamespaceTarget') {
+          state.util.replaceWith(obj, (i) => i.import('m', '*'));
+        }
+      },
+    });
     let code = transform(`
       export default function() {
         return myNamespaceTarget.thing('a') + " " + myNamespaceTarget.default('b');
@@ -90,6 +185,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('namespace binding avoids namespace imports', () => {
+    makePlugin({
+      MemberExpression(path, state) {
+        let obj = path.get('object');
+        if (!obj.isIdentifier()) {
+          return;
+        }
+        if (obj.node.name === 'myNamespaceTarget') {
+          state.util.replaceWith(obj, (i) => i.import('m', '*'));
+        }
+      },
+    });
     let code = transform(`
       import * as foo from 'm';
       export default function(foo) {
@@ -101,6 +207,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('namespace binding avoids named imports', () => {
+    makePlugin({
+      MemberExpression(path, state) {
+        let obj = path.get('object');
+        if (!obj.isIdentifier()) {
+          return;
+        }
+        if (obj.node.name === 'myNamespaceTarget') {
+          state.util.replaceWith(obj, (i) => i.import('m', '*'));
+        }
+      },
+    });
     let code = transform(`
       import { x } from 'm';
       export default function() {
@@ -112,6 +229,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('namespace binding uses namespaced imports', () => {
+    makePlugin({
+      MemberExpression(path, state) {
+        let obj = path.get('object');
+        if (!obj.isIdentifier()) {
+          return;
+        }
+        if (obj.node.name === 'myNamespaceTarget') {
+          state.util.replaceWith(obj, (i) => i.import('m', '*'));
+        }
+      },
+    });
     let code = transform(`
       import * as b from 'm';
       export default function() {
@@ -123,6 +251,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('namespace binding uses default imports', () => {
+    makePlugin({
+      MemberExpression(path, state) {
+        let obj = path.get('object');
+        if (!obj.isIdentifier()) {
+          return;
+        }
+        if (obj.node.name === 'myNamespaceTarget') {
+          state.util.replaceWith(obj, (i) => i.import('m', '*'));
+        }
+      },
+    });
     let code = transform(`
       import b from 'm';
       export default function() {
@@ -134,6 +273,19 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('named binding avoids namespace import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        } else if (callee.node.name === 'second') {
+          state.util.replaceWith(callee, (i) => i.import('n', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       import * as x from 'm';
       export default function () {
@@ -153,6 +305,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('can use an optional name hint', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myHintTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'default', 'HINT'));
+        }
+      },
+    });
     let code = transform(`
       export default function() {
         return myHintTarget('foo');
@@ -163,6 +326,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('sanitizes name hint to make it a valid javascript identifier', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myMessyHintTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'default', 'this-is: the hint!'));
+        }
+      },
+    });
     let code = transform(`
       export default function() {
         return myMessyHintTarget('foo');
@@ -173,6 +347,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('avoids an existing local binding', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       export default function() {
         let thing = 'hello';
@@ -184,6 +369,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('uses an existing import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       import { thing } from 'm';
       export default function() {
@@ -195,6 +391,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('does not use an existing type-only import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       import type { thing } from 'm';
       export default function() {
@@ -211,6 +418,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('adds to an existing import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       import { other } from 'm';
       export default function() {
@@ -223,6 +441,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('does not add to an existing type-only import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       import type { other } from 'm';
       export default function() {
@@ -239,6 +468,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('adds to an existing value import with an unrelated type-only specifier', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       import { type other } from 'm';
       export default function() {
@@ -254,6 +494,19 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('subsequent imports avoid previously created bindings', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        } else if (callee.node.name === 'second') {
+          state.util.replaceWith(callee, (i) => i.import('n', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       export default function() {
         return myTarget("a") + " | " + second("b");
@@ -265,6 +518,19 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('multiple uses share an import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        } else if (callee.node.name === 'myDefaultTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'default'));
+        }
+      },
+    });
     let code = transform(`
       export default function() {
         return myTarget("a") + " | " + myTarget("b") + " | " + myDefaultTarget("c");
@@ -278,6 +544,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('multiple uses in different scopes share a specifier', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       function a() {
         return myTarget('a');
@@ -295,6 +572,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('resolves conflicts between different local scope collisions', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'thing'));
+        }
+      },
+    });
     let code = transform(`
       export default function() {
         let first = myTarget("a");
@@ -310,6 +598,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('can add a side-effect import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'needsSideEffectThing') {
+          state.util.importForSideEffect('side-effect-thing');
+        }
+      },
+    });
     let code = transform(`
       needsSideEffectThing();
     `);
@@ -317,6 +616,17 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('side-effect import has no effect on existing import', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'needsSideEffectThing') {
+          state.util.importForSideEffect('side-effect-thing');
+        }
+      },
+    });
     let code = transform(`
       import x from 'side-effect-thing';
       needsSideEffectThing();
@@ -326,6 +636,13 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('can remove one specifier', () => {
+    makePlugin({
+      Program: {
+        exit(_path, state) {
+          state.util.removeImport('whatever', 'a');
+        },
+      },
+    });
     let code = transform(`
       import { a, b } from 'whatever';
       import other from 'x';
@@ -335,6 +652,13 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('can remove whole statement', () => {
+    makePlugin({
+      Program: {
+        exit(_path, state) {
+          state.util.removeImport('whatever', 'a');
+        },
+      },
+    });
     let code = transform(`
       import { a } from 'whatever';
       import other from 'x';
@@ -344,6 +668,13 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('can remove namespace import', () => {
+    makePlugin({
+      Program: {
+        exit(_path, state) {
+          state.util.removeImport('remove-my-namespace', '*');
+        },
+      },
+    });
     let code = transform(`
       import * as a from 'remove-my-namespace';
       import * as other from 'x';
@@ -353,69 +684,124 @@ function importUtilTests(transform: (code: string) => string) {
   });
 
   test('can remove all imports', () => {
+    makePlugin({
+      Program: {
+        exit(_path, state) {
+          state.util.removeAllImports('remove-all');
+        },
+      },
+    });
     let code = transform(`
       import 'remove-all';
     `);
     expect(code).not.toMatch(/remove-all/);
   });
-}
 
-interface State {
-  adder: ImportUtil;
-}
-
-function testTransform(babel: { types: typeof t }): unknown {
-  return {
-    visitor: {
-      Program: {
-        enter(path: NodePath<t.Program>, state: State) {
-          state.adder = new ImportUtil(babel.types, path);
-        },
-        exit(_path: NodePath<t.Program>, state: State) {
-          state.adder.removeImport('whatever', 'a');
-          state.adder.removeImport('remove-my-namespace', '*');
-          state.adder.removeAllImports('remove-all');
-        },
-      },
-      CallExpression(path: NodePath<t.CallExpression>, state: State) {
+  test('inserts identifier correctly when replacing a larger expression', () => {
+    makePlugin({
+      CallExpression(path, state) {
         let callee = path.get('callee');
         if (!callee.isIdentifier()) {
           return;
         }
-        if (callee.node.name === 'myTarget') {
-          callee.replaceWith(state.adder.import(callee, 'm', 'thing'));
-        } else if (callee.node.name === 'second') {
-          callee.replaceWith(state.adder.import(callee, 'n', 'thing'));
-        } else if (callee.node.name === 'myDefaultTarget') {
-          callee.replaceWith(state.adder.import(callee, 'm', 'default'));
-        } else if (callee.node.name === 'myHintTarget') {
-          callee.replaceWith(state.adder.import(callee, 'm', 'default', 'HINT'));
-        } else if (callee.node.name === 'myMessyHintTarget') {
-          callee.replaceWith(state.adder.import(callee, 'm', 'default', 'this-is: the hint!'));
-        } else if (callee.node.name === 'needsSideEffectThing') {
-          state.adder.importForSideEffect('side-effect-thing');
+        if (callee.node.name === 'replacesWholeExpression') {
+          state.util.replaceWith(path, (i) =>
+            t.callExpression(i.import('m', 'impl'), [t.stringLiteral('x')])
+          );
         }
       },
-      MemberExpression(path: NodePath<t.MemberExpression>, state: State) {
-        let obj = path.get('object');
-        if (!obj.isIdentifier()) {
+    });
+    let code = transform(`
+      replacesWholeExpression()
+    `);
+    expect(code).toEqualCode(`
+      import { impl } from 'm';
+      impl('x');
+    `);
+  });
+
+  test("handles scope collisions within the user's new expression", () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
           return;
         }
-        if (obj.node.name === 'myNamespaceTarget') {
-          obj.replaceWith(state.adder.import(obj, 'm', '*'));
+        if (callee.node.name === 'target') {
+          state.util.replaceWith(path, (i) =>
+            t.functionExpression(
+              null,
+              [t.identifier('impl')],
+              t.blockStatement([
+                t.expressionStatement(
+                  t.callExpression(i.import('m', 'impl'), [t.stringLiteral('x')])
+                ),
+              ])
+            )
+          );
         }
       },
-    },
-  };
-}
+    });
+    let code = transform(`
+      target()
+    `);
+    expect(code).toEqualCode(`
+      import { impl as impl0} from 'm';
+      (function (impl) {
+        impl0("x");
+      });
+    `);
+  });
 
-describe('import-adder', () => {
-  allBabelVersions({
-    babelConfig() {
-      return {
-        plugins: [testTransform, TSSyntax],
-      };
-    },
-    createTests: importUtilTests,
+  test('can insertsAfter', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'target') {
+          state.util.insertAfter(path, (i) =>
+            t.callExpression(i.import('m', 'impl'), [t.stringLiteral('x')])
+          );
+        }
+      },
+    });
+    let code = transform(`
+      target()
+    `);
+    expect(code).toEqualCode(`
+      import { impl } from 'm';
+      target();
+      impl('x');
+    `);
+  });
+
+  test('can insertBefore', () => {
+    makePlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'target') {
+          state.util.insertBefore(path, (i) =>
+            t.callExpression(i.import('m', 'impl'), [t.stringLiteral('x')])
+          );
+        }
+      },
+    });
+    let code = transform(`
+      target()
+    `);
+    expect(code).toEqualCode(`
+      import { impl } from 'm';
+      impl('x');
+      target();
+    `);
   });
 });
+
+interface State {
+  util: ImportUtil;
+}

--- a/__tests__/test-support.ts
+++ b/__tests__/test-support.ts
@@ -1,5 +1,5 @@
 import 'jest';
-import { transform as transform7, TransformOptions as Options7 } from '@babel/core';
+import { transform as transform7 } from '@babel/core';
 import { createContext, Script } from 'vm';
 
 interface RunDefaultOptions {
@@ -34,61 +34,8 @@ export function runDefault(code: string, opts: RunDefaultOptions = {}): any {
   return context.exports.default();
 }
 
-function presetsFor(_major: 7) {
-  return [
-    [
-      require.resolve('@babel/preset-env'),
-      {
-        modules: false,
-        targets: {
-          ie: '11.0.0',
-        },
-      },
-    ],
-  ];
-}
-
 export interface Transform {
   (code: string, opts?: { filename?: string }): string;
   babelMajorVersion: 6 | 7;
   usingPresets: boolean;
-}
-
-export function allBabelVersions(params: {
-  babelConfig(major: 7): Options7;
-  createTests(transform: Transform): void;
-  includePresetsTests?: boolean;
-}) {
-  function versions(usePresets: boolean) {
-    describe('babel7', function () {
-      function transform(code: string, opts?: { filename?: string }) {
-        let options7: Options7 = params.babelConfig(7);
-        if (!options7.filename) {
-          options7.filename = 'sample.js';
-        }
-        if (usePresets) {
-          options7.presets = presetsFor(7);
-        }
-        if (opts && opts.filename) {
-          options7.filename = opts.filename;
-        }
-
-        return transform7(code, options7)!.code!;
-      }
-      transform.babelMajorVersion = 7 as const;
-      transform.usingPresets = usePresets;
-      params.createTests(transform);
-    });
-  }
-
-  if (params.includePresetsTests) {
-    describe('with presets', function () {
-      versions(true);
-    });
-    describe('without presets', function () {
-      versions(false);
-    });
-  } else {
-    versions(false);
-  }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.14.5",
     "@babel/plugin-transform-typescript": "^7.14.6",
     "@babel/preset-env": "^7.14.7",
+    "@types/babel__core": "^7.20.5",
     "@types/babel__traverse": "^7.11.1",
     "@types/jest": "^29.5.3",
     "@typescript-eslint/eslint-plugin": "^4.26.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,15 +38,14 @@ export class ImportUtil {
     }
   }
 
-  /**
-   * @deprecated This method is error prone because we cannot automatically
-   * ensure that babel's scope system will createa reference to the identifier
-   * after you have inserted it somewhere. The newer methods `insertBefore`,
-   * `insertAfter`, `replaceWith`, and `mutate` all provide more
-   * automatically-safe binding management.
-   */
   // Import the given value (if needed) and return an Identifier representing
   // it.
+  //
+  // This method is trickier to use safely than our higher-level methods
+  // (`insertAfter`, `insertBefore`, `replaceWith`, `mutate`) because after you
+  // insert the identifier into the AST, it's up to you to ensure that babel's
+  // scope system is aware of the new reference. The other methods do that for
+  // you automatically.
   import(
     // the spot at which you will insert the Identifier we return to you
     target: NodePath<t.Node>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,15 @@ export class ImportUtil {
     target: NodePath<T>,
     fn: (i: Importer) => R
   ): NodePath<R> {
-    return this.mutate((i) => target.replaceWith(fn(i))[0], defaultNameHint(target));
+    return this.mutate((i) => {
+      target.replaceWith(fn(i));
+      // the return value of replaceWith is not a reliable way to get the
+      // updated path, at least in the case where the user replaced an
+      // expression with a statement. Instead we will rely on the fact that path
+      // replacement also mutates its argument, so `target` now points at the
+      // newly replaced path.
+      return target as unknown as NodePath<R>;
+    }, defaultNameHint(target));
   }
 
   insertAfter<T extends t.Node, R extends t.Node>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,6 +1292,17 @@
     "@types/babel__template" "*"
     "@types/babel__traverse" "*"
 
+"@types/babel__core@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
+  integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
+  dependencies:
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
 "@types/babel__generator@*":
   version "7.6.4"
   resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.4.tgz#1f20ce4c5b1990b37900b63f050182d28c2439b7"


### PR DESCRIPTION
This adds new API in order to guarantee that every identifier we create for you ends up with a valid reference in babel's binding system.

Previously, we created the bindings but it was up to callers to take the Identifiers we hand them and get them into the AST somewhere and then wire up the references. This is error prone. Depending on the methods you use, *sometimes* babel will do it for you. Depending on the other plugins in play, *sometimes* it doesn't matter when you get valid references.

Using the new methods,  users must manipulate the AST within blocks of code wrapped by babel-import-util, ensuring that we can always install the correct references after your manipulations are done.

The primary methods are now:

 - replaceWith
 - insertAfter
 - insertBefore

These work just like the babel equivalents on NodePath, except they take a callback for building the replacement Node, and that callback has the ability to generate imports.

There is also a lower-level `mutate` method that leaves the path mutations up to you, and requires you to return the modified path to babel-import-util.

Along with this change I refactored the tests to keep each test's example transform alongside the test itself. They should demonstrate many ways a plugin can use the library.

I considered removing or deprecating the original `import` method since it doesn't provide this level of safety. But then I found a use case where I still wanted it. In that use case, the plugin was already responsible for wiring up bindings to many things, some of which were imported and some of which were not. So it was easier to continue getting an un-referenced identifier from babel-import-util and rely on the other existing code to handle reference creation.