### PR TITLE
Preserve non-leading numbers in name hints

### DIFF
--- a/__tests__/import-util.test.ts
+++ b/__tests__/import-util.test.ts
@@ -400,6 +400,27 @@ describe('ImportUtil', () => {
     expect(code).toMatch(/import thisIsTheHint from ['"]m['"]/);
   });
 
+  test('preserves non-leading numbers in name hints', () => {
+    addPlugin({
+      CallExpression(path, state) {
+        let callee = path.get('callee');
+        if (!callee.isIdentifier()) {
+          return;
+        }
+        if (callee.node.name === 'myMessyHintTarget') {
+          state.util.replaceWith(callee, (i) => i.import('m', 'default', 'i18n'));
+        }
+      },
+    });
+    let code = transform(`
+      export default function() {
+        return myMessyHintTarget('foo');
+      }
+      `);
+    expect(runDefault(code, { dependencies })).toEqual('default said: foo.');
+    expect(code).toMatch(/import i18n from ['"]m['"]/);
+  });
+
   test('avoids an existing local binding', () => {
     addPlugin({
       CallExpression(path, state) {

--- a/__tests__/sanitize.test.ts
+++ b/__tests__/sanitize.test.ts
@@ -1,0 +1,19 @@
+import { sanitize } from '../src/sanitize';
+
+describe('sanitize', () => {
+  test('handles leading number', () => {
+    expect(sanitize('1thing')).toBe('thing');
+  });
+
+  test('allows non-leading numbers', () => {
+    expect(sanitize('i18n')).toBe('i18n');
+  });
+
+  test('introduces camel case', () => {
+    expect(sanitize('this:thing')).toBe('thisThing');
+  });
+
+  test('trailing illegal char', () => {
+    expect(sanitize('this-is: the hint!')).toBe('thisIsTheHint');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type * as Babel from '@babel/core';
 import type { types as t, NodePath } from '@babel/core';
+import { sanitize } from './sanitize';
 
 export class ImportUtil {
   private t: typeof Babel.types;
@@ -307,13 +308,7 @@ function desiredName(
   defaultNameHint: string | undefined
 ) {
   if (nameHint) {
-    // first we opportunistically do camelization when an illegal character is
-    // followed by a lowercase letter, in an effort to aid readability of the
-    // output.
-    let cleaned = nameHint.replace(/[^a-zA-Z_]([a-z])/g, (_m, letter) => letter.toUpperCase());
-    // then we unliterally strip all remaining illegal characters.
-    cleaned = cleaned.replace(/[^a-zA-Z_]/g, '');
-    return cleaned;
+    return sanitize(nameHint);
   }
   if (exportedName === 'default' || exportedName === '*') {
     return defaultNameHint ?? 'a';

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,0 +1,16 @@
+// make a name into a valid javascript identifier, as pleasantly as possible.
+
+export function sanitize(identifier: string): string {
+  // first we opportunistically do camelization when an illegal character is not
+  // the first character and is followed by a lowercase letter, in an effort to
+  // aid readability of the output.
+  let cleaned = identifier.replace(
+    new RegExp(`(?<!^)(?:${illegalChar.source})([a-z])`, 'g'),
+    (_m, letter) => letter.toUpperCase()
+  );
+  // then we unliterally strip all remaining illegal characters.
+  cleaned = cleaned.replace(new RegExp(illegalChar.source, 'g'), '');
+  return cleaned;
+}
+
+const illegalChar = /^[^a-zA-Z_$]|(?<=.)[^a-zA-Z_$0-9]/;


### PR DESCRIPTION
The code that sanitizes names to make them valid javascript identifiers was unnecessarily simple and aggressive. It was forbidden all numbers, when the correct rule is only to forbid leading numbers.

This fixes an example like `i18n`, which was previously becoming `iN`.